### PR TITLE
Add cryptboot-grub-warning script

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -13,6 +13,7 @@ package() {
   cd "$srcdir/$pkgname-$pkgver"
   install -Dm755 cryptboot "$pkgdir/usr/bin/cryptboot"
   install -Dm755 cryptboot-efikeys "$pkgdir/usr/bin/cryptboot-efikeys"
+  install -Dm755 cryptboot-grub-warning "$pkgdir/etc/cryptboot-grub-warning"
   install -Dm644 cryptboot.conf "$pkgdir/etc/cryptboot.conf"
 }
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,12 @@ Installation
 7. Unmount `/boot` partition and EFI System partition:
 
         cryptboot umount
+        
+8. Optional: Install cryptboot-grub-warning script to raise an error if running `grub-install` directly instead of `cryptboot update-grub`:
 
-8. Reboot your system, you should be completely secured against evil maid attacks from now on!
+        ln -s /etc/cryptboot-grub-warning /usr/local/bin/grub-install
+
+9. Reboot your system, you should be completely secured against evil maid attacks from now on!
 
 Usage
 -----

--- a/cryptboot
+++ b/cryptboot
@@ -113,7 +113,7 @@ case "$1" in
     grub-mkconfig -o "$BOOT_DIR/grub/grub.cfg"
 
     echo "Reinstalling GRUB to EFI System partition..."
-    grub-install --target=x86_64-efi --boot-directory="$BOOT_DIR" --efi-directory="$EFI_DIR" --bootloader-id="$EFI_ID_GRUB"
+    /usr/bin/grub-install --target=x86_64-efi --boot-directory="$BOOT_DIR" --efi-directory="$EFI_DIR" --bootloader-id="$EFI_ID_GRUB"
 
     echo "Signing GRUB with UEFI Secure Boot keys..."
     "$EFIKEYS_BIN" sign "$EFI_DIR/$EFI_PATH_GRUB"

--- a/cryptboot-grub-warning
+++ b/cryptboot-grub-warning
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This file should be placed in your $PATH at a higher precedence than /usr/bin/grub-install (e.g. /usr/local/bin/grub-install)
+# to ensure that we always run `cryptboot update-grub` to sign the bootloader after the bootloader file is updated.
+
+red='\033[0;31m'
+nc='\033[0m'
+
+echo -e "${red}ERROR:\nRun 'cryptboot update-grub' instead of 'grub-install' to ensure bootloader is signed.\nFailure to sign the bootloader will cause subsequent Secure Boots to fail.${nc}"
+exit 1


### PR DESCRIPTION
- Place this script at /usr/local/bin/grub-install to raise an error
  telling the user to run `cryptboot update-grub` instead
- Little guard rail to prevent updating the bootloader and forgetting to
  sign the new binary
- Use absolute path to call `grub-install` in `cryptboot` script